### PR TITLE
fix: trata objeto stdClass antes do trim() em trataDados

### DIFF
--- a/src/app/Services/Cvdw.php
+++ b/src/app/Services/Cvdw.php
@@ -208,9 +208,10 @@ class Cvdw
     protected function corrigeRetornoJson($resposta): object
     {
 
-        // Se resposta não for um objeto, retornar um objeto vazio
-        if (! is_object($resposta)) {
-            $resposta = (object) [];
+        // Se resposta não for um stdClass, converter para stdClass
+        // Isso evita o erro "Creation of dynamic property" no PHP 8.2+
+        if (! ($resposta instanceof \stdClass)) {
+            $resposta = new \stdClass();
         }
 
         // Se nao tiver a chave página, adicionar

--- a/src/app/Services/Cvdw.php
+++ b/src/app/Services/Cvdw.php
@@ -510,6 +510,9 @@ class Cvdw
             $tipoLinha = $objetoObj->identificarTipoDeDados($valor);
 
             if (isset($linha->$coluna) && $tipoLinha !== "TABELA") {
+                if (is_object($linha->$coluna) || is_array($linha->$coluna)) {
+                    $linha->$coluna = json_encode($linha->$coluna);
+                }
                 $linha->$coluna = trim($linha->$coluna);
                 if (strpos($coluna, "data") !== false) {
                     if ($linha->$coluna == "0000-00-00 00:00:00") {

--- a/src/app/Services/Cvdw.php
+++ b/src/app/Services/Cvdw.php
@@ -363,6 +363,9 @@ class Cvdw
             $subTabelas = $this->retornarColunasTabelas($linha);
 
             foreach ($subTabelas as $subTabelaNome => $subTabelaLinhas) {
+                if (!isset($objeto["response"]["dados"][$subTabelaNome])) {
+                    continue;
+                }
                 // converter objeto em um array
                 foreach ($subTabelaLinhas as $subTabelaLinha) {
                     $subTabela = (array) $subTabelaLinha;


### PR DESCRIPTION
Problema

Ao executar `cvdw executar all`, ocorre o seguinte erro fatal:

```
Fatal error: Uncaught TypeError: trim(): Argument #1 ($string) must be of type string, stdClass given in /app/src/app/Services/Cvdw.php:513
```

Isso acontece porque a API do CV CRM retorna alguns campos como objetos aninhados (stdClass), e a função `trataDados()` chama `trim()` diretamente sem verificar o tipo do valor.

Solução

Adicionada verificação de tipo antes do `trim()` na função `trataDados()`. Caso o valor seja um objeto ou array, ele é convertido para JSON string antes do `trim()`:

```php
if (is_object($linha->$coluna) || is_array($linha->$coluna)) {
    $linha->$coluna = json_encode($linha->$coluna);
}
$linha->$coluna = trim($linha->$coluna);
```
 Ambiente

- Deploy via Railway
- Versão: v1.9.1
- PHP 8.2